### PR TITLE
Allow browser to cache CORS header values

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -49,6 +49,8 @@ LDAPCacheTTL ${LDAP_CACHE_TTL}
         Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin"
         Header unset Access-Control-Allow-Methods
         Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        Header unset Access-Control-Max-Age
+        Header always set Access-Control-Max-Age 1728000
 
         RewriteEngine On
         RewriteCond %{REQUEST_METHOD} OPTIONS
@@ -80,6 +82,8 @@ LDAPCacheTTL ${LDAP_CACHE_TTL}
         Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin"
         Header unset Access-Control-Allow-Methods
         Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        Header unset Access-Control-Max-Age
+        Header always set Access-Control-Max-Age 1728000
 
         RewriteEngine On
         RewriteCond %{REQUEST_METHOD} OPTIONS
@@ -111,6 +115,8 @@ LDAPCacheTTL ${LDAP_CACHE_TTL}
         Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin"
         Header unset Access-Control-Allow-Methods
         Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        Header unset Access-Control-Max-Age
+        Header always set Access-Control-Max-Age 1728000
 
         RewriteEngine On
         RewriteCond %{REQUEST_METHOD} OPTIONS


### PR DESCRIPTION
Having the browser request these constantly creates a ton of noise and makes debugging cumbersome. The values are unlikely to change often, so caching seems appropriate.
