### PR TITLE
allow sites to add arbitrary filters to Locations, will be used for http-level gzip

### DIFF
--- a/override.sh
+++ b/override.sh
@@ -106,3 +106,18 @@ fi
 if [ "$ENABLE_STACKDRIVER" = "yes" ]; then
     /usr/sbin/a2ensite stackdriver
 fi
+
+# update FILTER
+if [ -z "$FILTER" ] ; then
+    export FILTER=
+fi
+
+# update FILTER2
+if [ -z "$FILTER2" ] ; then
+    export FILTER2=
+fi
+
+# update FILTER3
+if [ -z "$FILTER3" ] ; then
+    export FILTER3=
+fi

--- a/site.conf
+++ b/site.conf
@@ -73,6 +73,8 @@ LDAPCacheTTL ${LDAP_CACHE_TTL}
 
         ProxyPass ${PROXY_URL}
         ProxyPassReverse ${PROXY_URL}
+
+        ${FILTER}
     </Location>
 
     <Location ${PROXY_PATH2}>
@@ -106,6 +108,8 @@ LDAPCacheTTL ${LDAP_CACHE_TTL}
 
         ProxyPass ${PROXY_URL2}
         ProxyPassReverse ${PROXY_URL2}
+
+        ${FILTER2}
     </Location>
 
     <Location ${PROXY_PATH3}>
@@ -139,6 +143,8 @@ LDAPCacheTTL ${LDAP_CACHE_TTL}
 
         ProxyPass ${PROXY_URL3}
         ProxyPassReverse ${PROXY_URL3}
+
+        ${FILTER3}
     </Location>
 
     <Location ${CALLBACK_PATH}>


### PR DESCRIPTION
For each of the three Location containers in site.conf, allow an additional line of override.

I realize this line could be used for anything; we intend to use it to add:
`AddOutputFilterByType DEFLATE [mime-types]`
incrementally across services as we test and ensure all is well.

I know that the default image enables DEFLATE for text/plain and other text types - however, it does not enable application/json by default, and that's the big one we need. By controlling on a per-service/per-Location basis, we have a lot more control.
