### PR TITLE
bump mpm_event settings significantly from default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ COPY modsecurity.conf /etc/modsecurity/modsecurity.conf
 COPY unicode.mapping /etc/modsecurity/unicode.mapping
 
 COPY site.conf stackdriver.conf /etc/apache2/sites-available/
+COPY mpm_event.conf /etc/apache2/conf-enabled/
 COPY override.sh /etc/apache2/
 
 RUN rm -f /root/modsecurity-${MOD_SECURITY_VERSION}.tar.gz

--- a/mpm_event.conf
+++ b/mpm_event.conf
@@ -1,0 +1,17 @@
+#
+# Increase mpm_event thread configurations for proxy.
+#  NOTE: the values are interrelated so changing one may require changing another
+#   plus one value may force apache to reset another to a lower value due to
+#   these inter-dependencies
+#
+
+<IfModule mpm_event_module>
+StartServers			 25
+ServerLimit             100
+MinSpareThreads		 5
+MaxSpareThreads		 3000
+ThreadsPerChild		 120
+ThreadLimit			 256
+MaxRequestWorkers	  12000
+MaxConnectionsPerChild   10000
+</IfModule>


### PR DESCRIPTION
I don't know how this gets rolled out. There is quite some variance in which versions of this proxy services use:

cromwell, job-manager, sam-fiab
broadinstitute/openidc-proxy:modsecurity_2_9_2

consent-local, consent-ontology-local
broadinstitute/openidc-proxy:latest

everything else:
broadinstitute/openidc-proxy:tcell

Please advise