### PR TITLE
[DDO-1606] Add a GitHub action to push images to GCR

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -54,7 +54,7 @@ jobs:
           service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
           service_account_key: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
 
-      - name: Explicitly auth Docker for Artifact Registry
+      - name: Explicitly auth Docker for GCR
         run: gcloud auth configure-docker $GOOGLE_DOCKER_REPOSITORY --quiet
 
       - name: Construct docker image name and tag

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,76 @@
+name: Bump, Tag, and Publish
+# The purpose of the workflow is to:
+#  1. Bump the version number and tag the release if not a PR
+#  2. Build docker image and publish to GCR
+#
+# When run on merge to main, it tags and bumps the patch version by default. You can
+# bump other parts of the version by putting #major, #minor, or #patch in your commit
+# message.
+#
+# When run on a PR, it simulates bumping the tag and appends a hash to the pushed image.
+#
+# The workflow relies on github secrets:
+# - GCR_PUBLISH_EMAIL - SA email for publishing to broad-dsp-gcr-public
+# - GCR_PUBLISH_KEY_B64 - SA key (Base64-encoded JSON string) for publishing to broad-dsp-gcr-public
+# - BROADBOT_TOKEN - the broadbot token, so we can avoid two reviewer rule on GHA operations
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+env:
+  # The Google project, which is also the name of the repository for GCR
+  GOOGLE_PROJECT: broad-dsp-gcr-public
+  # Name of the image to make in the GOOGLE_PROJECT repository
+  IMAGE_NAME: oauth2-baseimage
+  # Google Docker repository where the GOOGLE_PROJECT repository can be found
+  GOOGLE_DOCKER_REPOSITORY: us.gcr.io
+jobs:
+  tag-publish-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Bump the tag to a new version
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
+        id: tag
+        env:
+          DEFAULT_BUMP: patch
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          RELEASE_BRANCHES: master
+          WITH_V: true
+
+      - name: Auth to GCP
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '345.0.0'
+          service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
+          service_account_key: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+
+      - name: Explicitly auth Docker for Artifact Registry
+        run: gcloud auth configure-docker $GOOGLE_DOCKER_REPOSITORY --quiet
+
+      - name: Construct docker image name and tag
+        id: image-name
+        run: |
+          DOCKER_TAG=${{ steps.tag.outputs.tag }}
+          echo ::set-output name=name::${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${IMAGE_NAME}:${DOCKER_TAG}
+
+      - name: Build image
+        run: "docker build -t ${{ steps.image-name.outputs.name }} ."
+
+      - name: Run Trivy vulnerability scanner
+        # From https://github.com/broadinstitute/dsp-appsec-trivy-action
+        uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: ${{ steps.image-name.outputs.name }}
+
+      - name: Push image
+        run: "docker push ${{ steps.image-name.outputs.name }}"


### PR DESCRIPTION
Copied from Revere/Sherlock and adapted to reference GCR variables (as a small handrail against copy-pasting in the future) and exclude go-related things. Does a Trivy scan.

Also see https://github.com/broadinstitute/openidc-baseimage/pull/36